### PR TITLE
MENC-315: Update workflow selector for Windows based self-hosted runner

### DIFF
--- a/workflow-templates/psake-ci.yml
+++ b/workflow-templates/psake-ci.yml
@@ -26,7 +26,7 @@ on:
 jobs:
   ci:
     # This will execute the workflow on our self-hosted Windows VM
-    runs-on: [self-hosted, Windows]
+    runs-on: [self-hosted, Windows, CI, MSBuild-16.9]
 
     steps:
     - name: Checkout

--- a/workflow-templates/psake-release.yml
+++ b/workflow-templates/psake-release.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   release:
     # This will execute the workflow on our self-hosted Windows VM
-    runs-on: [self-hosted, Windows]
+    runs-on: [self-hosted, Windows, CI, MSBuild-16.9]
 
     steps:
     - name: Checkout

--- a/workflow-templates/psake-tryci.yml
+++ b/workflow-templates/psake-tryci.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   tryci:
-    runs-on: [self-hosted, Windows]
+    runs-on: [self-hosted, Windows, CI, MSBuild-16.9]
 
     steps:
     - name: Checkout


### PR DESCRIPTION

We need more unique selector than we are currently using to be able to add new Windows based self-hosted runners.

The `self-hosted` and `Windows` labels are automatically added to all Windows based self-hosted runners and there is no way to remove them.

For this reason we need to have more unique selectors so that other (new) runners don't take CI related tasks targetting MSBuild-16.9
